### PR TITLE
Use HTTPS for pypi's http api

### DIFF
--- a/pym/euscan/handlers/pypi.py
+++ b/pym/euscan/handlers/pypi.py
@@ -36,7 +36,7 @@ def scan_pkg(pkg, options):
 
     output.einfo("Using PyPi XMLRPC: " + package)
 
-    client = xmlrpclib.ServerProxy('http://pypi.python.org/pypi')
+    client = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
     versions = client.package_releases(package)
 
     if not versions:


### PR DESCRIPTION
pypi started to refuse plain http connections to it's api.